### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Model Context Protocol (MCP) server that connects to the Amadeus API to provide flight search, booking, and analysis capabilities for AI assistants.
 
+<a href="https://glama.ai/mcp/servers/@privilegemendes/amadeus-mcp-server-standalone">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@privilegemendes/amadeus-mcp-server-standalone/badge" alt="Amadeus Server MCP server" />
+</a>
+
 ## Features
 
 - **Flight Search**: Find flights between airports with various parameters
@@ -165,4 +169,4 @@ The server provides schema resources for:
 
 ## License
 
-MIT 
+MIT


### PR DESCRIPTION
This PR adds a badge for the [Amadeus MCP Server](https://glama.ai/mcp/servers/@privilegemendes/amadeus-mcp-server-standalone) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@privilegemendes/amadeus-mcp-server-standalone">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@privilegemendes/amadeus-mcp-server-standalone/badge" alt="Amadeus Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.